### PR TITLE
enabled ForwgroundImageView to be clickable

### DIFF
--- a/src/main/res/layout/gallery_view_image.xml
+++ b/src/main/res/layout/gallery_view_image.xml
@@ -12,6 +12,7 @@
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       android:foreground="@drawable/image_overlay"
+      android:clickable="true"
       tools:src="#f00"
       />
   <TextView


### PR DESCRIPTION
Fixed bug where the ForegroundImageView was not showing transparent overlay. 
