### PR TITLE
Fix use of endpoints

### DIFF
--- a/src/debug/java/com/jakewharton/u2020/data/ApiEndpoint.java
+++ b/src/debug/java/com/jakewharton/u2020/data/ApiEndpoint.java
@@ -6,5 +6,5 @@ import javax.inject.Qualifier;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Qualifier @Retention(RUNTIME)
-public @interface Endpoint {
+public @interface ApiEndpoint {
 }

--- a/src/debug/java/com/jakewharton/u2020/data/ApiEndpoints.java
+++ b/src/debug/java/com/jakewharton/u2020/data/ApiEndpoints.java
@@ -2,7 +2,7 @@ package com.jakewharton.u2020.data;
 
 import com.jakewharton.u2020.data.api.ApiModule;
 
-public enum Endpoints {
+public enum ApiEndpoints {
   PRODUCTION("Production", ApiModule.PRODUCTION_API_URL),
   // STAGING("Staging", "https://api.staging.imgur.com/3/"),
   MOCK_MODE("Mock Mode", "mock://"),
@@ -11,7 +11,7 @@ public enum Endpoints {
   public final String name;
   public final String url;
 
-  Endpoints(String name, String url) {
+  ApiEndpoints(String name, String url) {
     this.name = name;
     this.url = url;
   }
@@ -20,8 +20,8 @@ public enum Endpoints {
     return name;
   }
 
-  public static Endpoints from(String endpoint) {
-    for (Endpoints value : values()) {
+  public static ApiEndpoints from(String endpoint) {
+    for (ApiEndpoints value : values()) {
       if (value.url != null && value.url.equals(endpoint)) {
         return value;
       }

--- a/src/debug/java/com/jakewharton/u2020/data/DebugDataModule.java
+++ b/src/debug/java/com/jakewharton/u2020/data/DebugDataModule.java
@@ -41,13 +41,13 @@ public final class DebugDataModule {
     return client;
   }
 
-  @Provides @Singleton @Endpoint
+  @Provides @Singleton @ApiEndpoint
   StringPreference provideEndpointPreference(SharedPreferences preferences) {
-    return new StringPreference(preferences, "debug_endpoint", Endpoints.MOCK_MODE.url);
+    return new StringPreference(preferences, "debug_endpoint", ApiEndpoints.MOCK_MODE.url);
   }
 
-  @Provides @Singleton @IsMockMode boolean provideIsMockMode(@Endpoint StringPreference endpoint) {
-    return Endpoints.isMockMode(endpoint.get());
+  @Provides @Singleton @IsMockMode boolean provideIsMockMode(@ApiEndpoint StringPreference endpoint) {
+    return ApiEndpoints.isMockMode(endpoint.get());
   }
 
   @Provides @Singleton @NetworkProxy

--- a/src/debug/java/com/jakewharton/u2020/data/api/DebugApiModule.java
+++ b/src/debug/java/com/jakewharton/u2020/data/api/DebugApiModule.java
@@ -1,10 +1,14 @@
 package com.jakewharton.u2020.data.api;
 
 import android.content.SharedPreferences;
+import com.jakewharton.u2020.data.ApiEndpoint;
 import com.jakewharton.u2020.data.IsMockMode;
+import com.jakewharton.u2020.data.prefs.StringPreference;
 import dagger.Module;
 import dagger.Provides;
 import javax.inject.Singleton;
+import retrofit.Endpoint;
+import retrofit.Endpoints;
 import retrofit.MockRestAdapter;
 import retrofit.RestAdapter;
 import retrofit.android.AndroidMockValuePersistence;
@@ -15,6 +19,12 @@ import retrofit.android.AndroidMockValuePersistence;
     overrides = true
 )
 public final class DebugApiModule {
+
+  @Provides @Singleton
+  Endpoint provideEndpoint(@ApiEndpoint StringPreference apiEndpoint) {
+    return Endpoints.newFixedEndpoint(apiEndpoint.get());
+  }
+
   @Provides @Singleton
   MockRestAdapter provideMockRestAdapter(RestAdapter restAdapter, SharedPreferences preferences) {
     MockRestAdapter mockRestAdapter = MockRestAdapter.from(restAdapter);

--- a/src/debug/java/com/jakewharton/u2020/ui/debug/DebugAppContainer.java
+++ b/src/debug/java/com/jakewharton/u2020/ui/debug/DebugAppContainer.java
@@ -30,8 +30,8 @@ import com.jakewharton.u2020.BuildConfig;
 import com.jakewharton.u2020.R;
 import com.jakewharton.u2020.U2020App;
 import com.jakewharton.u2020.data.AnimationSpeed;
-import com.jakewharton.u2020.data.Endpoint;
-import com.jakewharton.u2020.data.Endpoints;
+import com.jakewharton.u2020.data.ApiEndpoint;
+import com.jakewharton.u2020.data.ApiEndpoints;
 import com.jakewharton.u2020.data.NetworkProxy;
 import com.jakewharton.u2020.data.PicassoDebugging;
 import com.jakewharton.u2020.data.PixelGridEnabled;
@@ -100,7 +100,7 @@ public class DebugAppContainer implements AppContainer {
   Context drawerContext;
 
   @Inject public DebugAppContainer(OkHttpClient client, Picasso picasso,
-      @Endpoint StringPreference networkEndpoint, @NetworkProxy StringPreference networkProxy,
+      @ApiEndpoint StringPreference networkEndpoint, @NetworkProxy StringPreference networkProxy,
       @AnimationSpeed IntPreference animationSpeed,
       @PicassoDebugging BooleanPreference picassoDebugging,
       @PixelGridEnabled BooleanPreference pixelGridEnabled,
@@ -217,17 +217,17 @@ public class DebugAppContainer implements AppContainer {
   }
 
   private void setupNetworkSection() {
-    final Endpoints currentEndpoint = Endpoints.from(networkEndpoint.get());
-    final EnumAdapter<Endpoints> endpointAdapter =
-        new EnumAdapter<>(drawerContext, Endpoints.class);
+    final ApiEndpoints currentEndpoint = ApiEndpoints.from(networkEndpoint.get());
+    final EnumAdapter<ApiEndpoints> endpointAdapter =
+        new EnumAdapter<>(drawerContext, ApiEndpoints.class);
     endpointView.setAdapter(endpointAdapter);
     endpointView.setSelection(currentEndpoint.ordinal());
     endpointView.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
       @Override
       public void onItemSelected(AdapterView<?> adapterView, View view, int position, long id) {
-        Endpoints selected = endpointAdapter.getItem(position);
+        ApiEndpoints selected = endpointAdapter.getItem(position);
         if (selected != currentEndpoint) {
-          if (selected == Endpoints.CUSTOM) {
+          if (selected == ApiEndpoints.CUSTOM) {
             Timber.d("Custom network endpoint selected. Prompting for URL.");
             showCustomEndpointDialog(currentEndpoint.ordinal(), "http://");
           } else {
@@ -326,9 +326,9 @@ public class DebugAppContainer implements AppContainer {
     });
 
     // Only show the endpoint editor when a custom endpoint is in use.
-    endpointEditView.setVisibility(currentEndpoint == Endpoints.CUSTOM ? VISIBLE : GONE);
+    endpointEditView.setVisibility(currentEndpoint == ApiEndpoints.CUSTOM ? VISIBLE : GONE);
 
-    if (currentEndpoint == Endpoints.MOCK_MODE) {
+    if (currentEndpoint == ApiEndpoints.MOCK_MODE) {
       // Disable network proxy if we are in mock mode.
       networkProxyView.setEnabled(false);
       networkLoggingView.setEnabled(false);

--- a/src/main/java/com/jakewharton/u2020/data/api/ApiModule.java
+++ b/src/main/java/com/jakewharton/u2020/data/api/ApiModule.java
@@ -4,8 +4,9 @@ import com.squareup.okhttp.OkHttpClient;
 import dagger.Module;
 import dagger.Provides;
 import javax.inject.Singleton;
+import retrofit.Endpoint;
+import retrofit.Endpoints;
 import retrofit.RestAdapter;
-import retrofit.Server;
 import retrofit.client.Client;
 import retrofit.client.OkClient;
 
@@ -21,8 +22,8 @@ public final class ApiModule {
     return CLIENT_ID;
   }
 
-  @Provides @Singleton Server provideServer() {
-    return new Server(PRODUCTION_API_URL);
+  @Provides @Singleton Endpoint provideEndpoint() {
+    return Endpoints.newFixedEndpoint(PRODUCTION_API_URL);
   }
 
   @Provides @Singleton Client provideClient(OkHttpClient client) {
@@ -30,10 +31,10 @@ public final class ApiModule {
   }
 
   @Provides @Singleton
-  RestAdapter provideRestAdapter(Server server, Client client, ApiHeaders headers) {
+  RestAdapter provideRestAdapter(Endpoint endpoint, Client client, ApiHeaders headers) {
     return new RestAdapter.Builder() //
         .setClient(client) //
-        .setServer(server) //
+        .setEndpoint(endpoint) //
         .setRequestInterceptor(headers) //
         .build();
   }


### PR DESCRIPTION
Endpoints were previously not used in Debug build (it was only possible to use Prod URL or MockMode).
Retrofit's `Server` is deprecated, so I changed it to use Retrofit's `Endpoints` but then it makes our internal `Endpoints` ambiguous.
Should I rename the Dagger qualifiers or use the fully qualified name as it is now?
