### PR TITLE
Updates support for Android Studio 0.8.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:0.9.+'
+    classpath 'com.android.tools.build:gradle:0.12.+'
     classpath 'com.jakewharton.hugo:hugo-plugin:1.0.+'
     classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.9.+'
   }
@@ -53,7 +53,7 @@ def preDexEnabled = "true".equals(System.getProperty("pre-dex", "true"))
 
 android {
   compileSdkVersion 19
-  buildToolsVersion "19.0.1"
+  buildToolsVersion "19.1.0"
 
   dexOptions {
     // Skip pre-dexing when running on Travis CI or when disabled via -Dpre-dex=false.
@@ -73,7 +73,7 @@ android {
 
   buildTypes {
     debug {
-      packageNameSuffix '.dev'
+      applicationIdSuffix '.dev'
       versionNameSuffix '-dev'
     }
   }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 24 18:15:27 SGT 2014
+#Tue Jul 08 19:25:14 PDT 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip


### PR DESCRIPTION
Takes care of updating U2020 for Android Studio (beta) 0.8.1
- Updates Build Tools
- Updates Gradle Distribution
- Refactors variable names to match new API
