### PR TITLE
upgrade Hugo to 1.1.+ & SdkManager to 0.10.+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:0.12.+'
-    classpath 'com.jakewharton.hugo:hugo-plugin:1.0.+'
-    classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.9.+'
+    classpath 'com.jakewharton.hugo:hugo-plugin:1.1.+'
+    classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.10.+'
   }
 }
 


### PR DESCRIPTION
fixes 'No such property: runtimeJarList for class:
com.android.build.gradle.AppPlugin' error on latest version of tools
