### PR TITLE
Removes AppContainer's dependency on U2020App

### DIFF
--- a/src/debug/java/com/jakewharton/u2020/ui/debug/DebugAppContainer.java
+++ b/src/debug/java/com/jakewharton/u2020/ui/debug/DebugAppContainer.java
@@ -3,6 +3,7 @@ package com.jakewharton.u2020.ui.debug;
 import android.animation.ValueAnimator;
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.app.Application;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -94,8 +95,8 @@ public class DebugAppContainer implements AppContainer {
   private final BooleanPreference seenDebugDrawer;
   private final RestAdapter restAdapter;
   private final MockRestAdapter mockRestAdapter;
+  private final Application app;
 
-  U2020App app;
   Activity activity;
   Context drawerContext;
 
@@ -108,7 +109,7 @@ public class DebugAppContainer implements AppContainer {
       @ScalpelEnabled BooleanPreference scalpelEnabled,
       @ScalpelWireframeEnabled BooleanPreference scalpelWireframeEnabled,
       @SeenDebugDrawer BooleanPreference seenDebugDrawer, RestAdapter restAdapter,
-      MockRestAdapter mockRestAdapter) {
+      MockRestAdapter mockRestAdapter, Application app) {
     this.client = client;
     this.picasso = picasso;
     this.networkEndpoint = networkEndpoint;
@@ -122,6 +123,7 @@ public class DebugAppContainer implements AppContainer {
     this.pixelGridEnabled = pixelGridEnabled;
     this.pixelRatioEnabled = pixelRatioEnabled;
     this.restAdapter = restAdapter;
+    this.app = app;
   }
 
   @InjectView(R.id.debug_drawer_layout) DrawerLayout drawerLayout;
@@ -170,8 +172,7 @@ public class DebugAppContainer implements AppContainer {
   @InjectView(R.id.debug_picasso_transformed_total) TextView picassoTransformedTotalView;
   @InjectView(R.id.debug_picasso_transformed_avg) TextView picassoTransformedAvgView;
 
-  @Override public ViewGroup get(final Activity activity, U2020App app) {
-    this.app = app;
+  @Override public ViewGroup get(final Activity activity) {
     this.activity = activity;
     drawerContext = activity;
 
@@ -623,6 +624,6 @@ public class DebugAppContainer implements AppContainer {
     Intent newApp = new Intent(app, MainActivity.class);
     newApp.setFlags(FLAG_ACTIVITY_CLEAR_TASK | FLAG_ACTIVITY_NEW_TASK);
     app.startActivity(newApp);
-    app.buildObjectGraphAndInject();
+    U2020App.get(app).buildObjectGraphAndInject();
   }
 }

--- a/src/main/java/com/jakewharton/u2020/ui/AppContainer.java
+++ b/src/main/java/com/jakewharton/u2020/ui/AppContainer.java
@@ -2,18 +2,17 @@ package com.jakewharton.u2020.ui;
 
 import android.app.Activity;
 import android.view.ViewGroup;
-import com.jakewharton.u2020.U2020App;
 
 import static butterknife.ButterKnife.findById;
 
 /** An indirection which allows controlling the root container used for each activity. */
 public interface AppContainer {
   /** The root {@link android.view.ViewGroup} into which the activity should place its contents. */
-  ViewGroup get(Activity activity, U2020App app);
+  ViewGroup get(Activity activity);
 
   /** An {@link AppContainer} which returns the normal activity content view. */
   AppContainer DEFAULT = new AppContainer() {
-    @Override public ViewGroup get(Activity activity, U2020App app) {
+    @Override public ViewGroup get(Activity activity) {
       return findById(activity, android.R.id.content);
     }
   };

--- a/src/main/java/com/jakewharton/u2020/ui/MainActivity.java
+++ b/src/main/java/com/jakewharton/u2020/ui/MainActivity.java
@@ -18,7 +18,7 @@ public class MainActivity extends Activity {
     U2020App app = U2020App.get(this);
     app.inject(this);
 
-    container = appContainer.get(this, app);
+    container = appContainer.get(this);
 
     getLayoutInflater().inflate(R.layout.gallery_view, container);
   }


### PR DESCRIPTION
The AppContainer interface's get(Activity, U2020App) method has a U2020App parameter that is only used in DebugAppContainer and not the DEFAULT app container.  If it is not required by all implementations, it should not be required in the interface.
