### PR TITLE
Replace JsonSerializer/Deserializer with TypeAdapter.

### DIFF
--- a/src/main/java/com/jakewharton/u2020/data/DateTimeConverter.java
+++ b/src/main/java/com/jakewharton/u2020/data/DateTimeConverter.java
@@ -1,29 +1,23 @@
 package com.jakewharton.u2020.data;
 
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonSerializer;
-import java.lang.reflect.Type;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
-public final class DateTimeConverter
-    implements JsonSerializer<DateTime>, JsonDeserializer<DateTime> {
+public final class DateTimeConverter extends TypeAdapter<DateTime> {
   private static final DateTimeFormatter DATE_TIME_FORMAT =
       DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
 
-  @Override public JsonElement serialize(DateTime src, Type typeOfSrc,
-      JsonSerializationContext context) {
-    return new JsonPrimitive(DATE_TIME_FORMAT.print(src));
+  @Override public void write(JsonWriter out, DateTime value)
+      throws IOException {
+    out.value(DATE_TIME_FORMAT.print(value));
   }
 
-  @Override public DateTime deserialize(JsonElement json, Type typeOfT,
-      JsonDeserializationContext context) throws JsonParseException {
-    return DATE_TIME_FORMAT.parseDateTime(json.getAsString());
+  @Override public DateTime read(JsonReader in) throws IOException {
+    return DATE_TIME_FORMAT.parseDateTime(in.nextString());
   }
 }


### PR DESCRIPTION
From the `JsonSerializer` javadoc
> New applications should prefer TypeAdapter, whose streaming API is more efficient than this interface's tree API.

I don't think the code is any harder to understand, and it's nice to demonstrate a more efficient alternative to custom type adapters in Gson.