### PR TITLE
Add instrumentation test infrastructure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: android
 
 jdk:
- - oraclejdk7
  - oraclejdk8
 
 android:
@@ -9,6 +8,17 @@ android:
     - build-tools-22.0.1
     - android-22
     - extra-android-m2repository
+    - sys-img-armeabi-v7a-android-19
+
+before_script:
+  - echo no | android create avd --force -n test -t android-19 --abi armeabi-v7a
+  - emulator -avd test -no-skin -no-audio -no-window &
+  - android-wait-for-emulator
+  - adb shell input keyevent 82 &
+
+env:
+  global:
+    - ADB_INSTALL_TIMEOUT=8
 
 notifications:
   email: false

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,8 @@ android {
 
     buildConfigField "String", "GIT_SHA", "\"${gitSha}\""
     buildConfigField "String", "BUILD_TIME", "\"${buildTime}\""
+
+    testInstrumentationRunner "com.jakewharton.u2020.U2020TestRunner"
   }
 
   buildTypes {
@@ -88,6 +90,10 @@ android {
     sourceCompatibility JavaVersion.VERSION_1_7
     targetCompatibility JavaVersion.VERSION_1_7
   }
+
+  packagingOptions {
+    exclude 'LICENSE.txt'
+  }
 }
 
 // TODO remove eventually: http://b.android.com/162285
@@ -96,10 +102,10 @@ configurations {
 }
 
 dependencies {
-  compile 'com.android.support:support-v4:22.1.1'
-  compile 'com.android.support:support-annotations:22.1.1'
-  compile 'com.android.support:appcompat-v7:22.1.1'
-  compile 'com.android.support:recyclerview-v7:22.1.1'
+  compile 'com.android.support:support-v4:22.2.0'
+  compile 'com.android.support:support-annotations:22.2.0'
+  compile 'com.android.support:appcompat-v7:22.2.0'
+  compile 'com.android.support:recyclerview-v7:22.2.0'
 
   compile 'com.squareup.dagger:dagger:1.2.2'
   apt 'com.squareup.dagger:dagger-compiler:1.2.2'
@@ -120,6 +126,13 @@ dependencies {
 
   compile 'net.danlew:android.joda:2.7.1'
   internalCompile 'com.mattprecious.telescope:telescope:1.4.0@aar'
+
+  androidTestCompile 'junit:junit:4.12'
+  androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2'
+  // TODO https://code.google.com/p/android-test-kit/issues/detail?id=157
+  //androidTestCompile 'com.android.support.test.espresso:espresso-contrib:2.2'
+  androidTestCompile 'com.android.support.test:runner:0.3'
+  androidTestCompile 'com.android.support.test:rules:0.3'
 }
 
 def installAll = tasks.create('installAll')
@@ -128,4 +141,9 @@ android.applicationVariants.all { variant ->
   installAll.dependsOn(variant.install)
   // Ensure we end up in the same group as the other install tasks.
   installAll.group = variant.install.group
+}
+
+// The default 'assemble' task only applies to normal variants. Add test variants as well.
+android.testVariants.all { variant ->
+  tasks.getByName('assemble').dependsOn variant.assemble
 }

--- a/src/androidTestInternal/java/com/jakewharton/u2020/U2020TestRunner.java
+++ b/src/androidTestInternal/java/com/jakewharton/u2020/U2020TestRunner.java
@@ -1,0 +1,37 @@
+package com.jakewharton.u2020;
+
+import android.app.KeyguardManager;
+import android.content.Context;
+import android.os.PowerManager;
+import android.support.test.runner.AndroidJUnitRunner;
+
+import static android.content.Context.KEYGUARD_SERVICE;
+import static android.content.Context.POWER_SERVICE;
+import static android.os.PowerManager.ACQUIRE_CAUSES_WAKEUP;
+import static android.os.PowerManager.FULL_WAKE_LOCK;
+import static android.os.PowerManager.ON_AFTER_RELEASE;
+
+public final class U2020TestRunner extends AndroidJUnitRunner {
+  @Override public void onStart() {
+    // Inform the app we are an instrumentation test before the object graph is initialized.
+    DebugU2020Module.instrumentationTest = true;
+
+    runOnMainSync(new Runnable() {
+      @SuppressWarnings("deprecation") // We don't care about deprecation here.
+      @Override public void run() {
+        Context app = getTargetContext().getApplicationContext();
+
+        String name = U2020TestRunner.class.getSimpleName();
+        // Unlock the device so that the tests can input keystrokes.
+        KeyguardManager keyguard = (KeyguardManager) app.getSystemService(KEYGUARD_SERVICE);
+        keyguard.newKeyguardLock(name).disableKeyguard();
+        // Wake up the screen.
+        PowerManager power = (PowerManager) app.getSystemService(POWER_SERVICE);
+        power.newWakeLock(FULL_WAKE_LOCK | ACQUIRE_CAUSES_WAKEUP | ON_AFTER_RELEASE, name)
+            .acquire();
+      }
+    });
+
+    super.onStart();
+  }
+}

--- a/src/androidTestInternal/java/com/jakewharton/u2020/ui/DummyTest.java
+++ b/src/androidTestInternal/java/com/jakewharton/u2020/ui/DummyTest.java
@@ -1,0 +1,22 @@
+package com.jakewharton.u2020.ui;
+
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.os.SystemClock.sleep;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+public final class DummyTest {
+  @Rule public final ActivityTestRule<MainActivity> main =
+      new ActivityTestRule<>(MainActivity.class);
+
+  @Test public void noneOfTheThings() {
+    sleep(SECONDS.toMillis(5)); // Long enough to see some data from mock mode.
+    assertTrue(true);
+  }
+}

--- a/src/internalDebug/java/com/jakewharton/u2020/DebugU2020Module.java
+++ b/src/internalDebug/java/com/jakewharton/u2020/DebugU2020Module.java
@@ -3,6 +3,8 @@ package com.jakewharton.u2020;
 import com.jakewharton.u2020.data.DebugDataModule;
 import com.jakewharton.u2020.ui.DebugUiModule;
 import dagger.Module;
+import dagger.Provides;
+import javax.inject.Singleton;
 
 @Module(
     addsTo = U2020Module.class,
@@ -13,4 +15,11 @@ import dagger.Module;
     overrides = true
 )
 public final class DebugU2020Module {
+  // Low-tech flag to force certain debug build behaviors when running in an instrumentation test.
+  // This value is used in the creation of singletons so it must be set before the graph is created.
+  static boolean instrumentationTest = false;
+
+  @Provides @Singleton @IsInstrumentationTest boolean provideIsInstrumentationTest() {
+    return instrumentationTest;
+  }
 }

--- a/src/internalDebug/java/com/jakewharton/u2020/IsInstrumentationTest.java
+++ b/src/internalDebug/java/com/jakewharton/u2020/IsInstrumentationTest.java
@@ -1,0 +1,10 @@
+package com.jakewharton.u2020;
+
+import java.lang.annotation.Retention;
+import javax.inject.Qualifier;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Qualifier @Retention(RUNTIME)
+public @interface IsInstrumentationTest {
+}

--- a/src/internalDebug/java/com/jakewharton/u2020/data/DebugDataModule.java
+++ b/src/internalDebug/java/com/jakewharton/u2020/data/DebugDataModule.java
@@ -3,6 +3,7 @@ package com.jakewharton.u2020.data;
 import android.app.Application;
 import android.content.SharedPreferences;
 import android.net.Uri;
+import com.jakewharton.u2020.IsInstrumentationTest;
 import com.jakewharton.u2020.data.api.DebugApiModule;
 import com.jakewharton.u2020.data.prefs.BooleanPreference;
 import com.jakewharton.u2020.data.prefs.IntPreference;
@@ -64,8 +65,10 @@ public final class DebugDataModule {
     return new StringPreference(preferences, "debug_endpoint", ApiEndpoints.MOCK_MODE.url);
   }
 
-  @Provides @Singleton @IsMockMode boolean provideIsMockMode(@ApiEndpoint StringPreference endpoint) {
-    return ApiEndpoints.isMockMode(endpoint.get());
+  @Provides @Singleton @IsMockMode boolean provideIsMockMode(@ApiEndpoint StringPreference endpoint,
+      @IsInstrumentationTest boolean isInstrumentationTest) {
+    // Running in an instrumentation forces mock mode.
+    return isInstrumentationTest || ApiEndpoints.isMockMode(endpoint.get());
   }
 
   @Provides @Singleton NetworkProxyPreference provideNetworkProxy(SharedPreferences preferences) {

--- a/src/internalDebug/java/com/jakewharton/u2020/ui/DebugUiModule.java
+++ b/src/internalDebug/java/com/jakewharton/u2020/ui/DebugUiModule.java
@@ -1,5 +1,6 @@
 package com.jakewharton.u2020.ui;
 
+import com.jakewharton.u2020.IsInstrumentationTest;
 import com.jakewharton.u2020.ui.debug.DebugAppContainer;
 import com.jakewharton.u2020.ui.debug.DebugView;
 import com.jakewharton.u2020.ui.debug.SocketActivityHierarchyServer;
@@ -17,8 +18,10 @@ import javax.inject.Singleton;
     overrides = true
 )
 public class DebugUiModule {
-  @Provides @Singleton AppContainer provideAppContainer(DebugAppContainer debugAppContainer) {
-    return debugAppContainer;
+  @Provides @Singleton AppContainer provideAppContainer(DebugAppContainer debugAppContainer,
+      @IsInstrumentationTest boolean isInstrumentationTest) {
+    // Do not add the debug controls for when we are running inside of an instrumentation test.
+    return isInstrumentationTest ? AppContainer.DEFAULT : debugAppContainer;
   }
 
   @Provides @Singleton ActivityHierarchyServer provideActivityHierarchyServer() {


### PR DESCRIPTION
A custom test runner subclass flips a boolean on a debug module before the graph is created. When the graph does get created, we use that boolean to force mock mode and skip wrapping the debug controls (both because it would never be used but also to ensure view-based matchers of Espresso work). We also kill the keyguard and hold a wake lock so that the screen is on and visible.

Closes #149. Closes #152.