### PR TITLE
Updated several libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,7 +141,7 @@ dependencies {
   internalDebugCompile 'com.squareup.retrofit:adapter-rxjava-mock:2.0.0-beta2'
 
   compile 'com.jakewharton:butterknife:7.0.1'
-  compile 'com.jakewharton.timber:timber:3.1.0'
+  compile 'com.jakewharton.timber:timber:4.0.1'
   compile 'com.jakewharton.byteunits:byteunits:0.9.1'
   compile 'com.jakewharton.rxbinding:rxbinding:0.2.0'
   internalDebugCompile 'com.jakewharton.madge:madge:1.1.2'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:1.3.1'
-    classpath 'com.neenbedankt.gradle.plugins:android-apt:1.7'
+    classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
     classpath('com.stanfy.spoon:spoon-gradle-plugin:1.0.3') {
       // Workaround for https://github.com/stanfy/spoon-gradle-plugin/issues/33
       exclude module: 'guava'
@@ -134,39 +134,39 @@ dependencies {
   compile 'com.squareup.okhttp:okhttp:2.5.0'
   compile 'com.squareup.picasso:picasso:2.5.2'
 
-  compile 'com.squareup.retrofit:retrofit:2.0.0-beta1'
-  compile 'com.squareup.retrofit:converter-moshi:2.0.0-beta1'
-  compile 'com.squareup.retrofit:adapter-rxjava:2.0.0-beta1'
-  internalDebugCompile 'com.squareup.retrofit:retrofit-mock:2.0.0-beta1'
-  internalDebugCompile 'com.squareup.retrofit:adapter-rxjava-mock:2.0.0-beta1'
+  compile 'com.squareup.retrofit:retrofit:2.0.0-beta2'
+  compile 'com.squareup.retrofit:converter-moshi:2.0.0-beta2'
+  compile 'com.squareup.retrofit:adapter-rxjava:2.0.0-beta2'
+  internalDebugCompile 'com.squareup.retrofit:retrofit-mock:2.0.0-beta2'
+  internalDebugCompile 'com.squareup.retrofit:adapter-rxjava-mock:2.0.0-beta2'
 
   compile 'com.jakewharton:butterknife:7.0.1'
-  compile 'com.jakewharton.timber:timber:3.0.2'
-  compile 'com.jakewharton.byteunits:byteunits:0.9.0'
+  compile 'com.jakewharton.timber:timber:3.1.0'
+  compile 'com.jakewharton.byteunits:byteunits:0.9.1'
   compile 'com.jakewharton.rxbinding:rxbinding:0.2.0'
-  internalDebugCompile 'com.jakewharton.madge:madge:1.1.1'
-  internalDebugCompile 'com.jakewharton.scalpel:scalpel:1.1.1'
-  internalDebugCompile 'com.jakewharton:process-phoenix:1.0.0'
+  internalDebugCompile 'com.jakewharton.madge:madge:1.1.2'
+  internalDebugCompile 'com.jakewharton.scalpel:scalpel:1.1.2'
+  internalDebugCompile 'com.jakewharton:process-phoenix:1.0.2'
 
-  internalCompile 'com.squareup.leakcanary:leakcanary-android:1.3'
-  productionCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.3'
+  internalCompile 'com.squareup.leakcanary:leakcanary-android:1.3.1'
+  productionCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.3.1'
 
   compile 'io.reactivex:rxjava:1.0.14'
   compile 'io.reactivex:rxandroid:1.0.1'
 
-  compile 'com.jakewharton.threetenabp:threetenabp:1.0.1'
+  compile 'com.jakewharton.threetenabp:threetenabp:1.0.2'
 
-  internalCompile 'com.mattprecious.telescope:telescope:1.4.0@aar'
+  internalCompile 'com.mattprecious.telescope:telescope:1.5.0@aar'
 
   compile 'com.f2prateek.rx.preferences:rx-preferences:1.0.0'
 
   androidTestCompile 'junit:junit:4.12'
-  androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2'
+  androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.1'
   // TODO https://code.google.com/p/android-test-kit/issues/detail?id=157
   //androidTestCompile 'com.android.support.test.espresso:espresso-contrib:2.2'
-  androidTestCompile 'com.android.support.test:runner:0.3'
-  androidTestCompile 'com.android.support.test:rules:0.3'
-  androidTestCompile 'com.squareup.spoon:spoon-client:1.1.9'
+  androidTestCompile 'com.android.support.test:runner:0.4.1'
+  androidTestCompile 'com.android.support.test:rules:0.4.1'
+  androidTestCompile 'com.squareup.spoon:spoon-client:1.2.0'
 
   testCompile 'junit:junit:4.12'
   testCompile 'com.google.truth:truth:0.27'


### PR DESCRIPTION
- Retrofit to 2.0.0-beta2
- Android-APT to 1.8
- Timber to 3.1.0
- ByteUnits to 0.9.1
- Madge to 1.1.2
- Scalpel to 1.1.2
- Process-Phoenix to 1.0.2
- LeakCanary to 1.3.1
- ThreeTenABP to 1.0.2
- Telescope to 1.5.0
- Spoon to 1.2.0
- Espresso (core to 2.2.1 and rules/runner to 0.4.1)