### PR TITLE
`no-skin` is removed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ android:
 
 before_script:
   - echo no | android create avd --force -n test -t android-19 --abi armeabi-v7a
-  - emulator -avd test -no-skin -no-audio -no-window &
+  - emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell settings put global window_animation_scale 0 &
   - adb shell settings put global transition_animation_scale 0 &


### PR DESCRIPTION
It removes device configuration when emulator initializes. It causes the device to be 320x480 with 240 or 320 display density. Which makes effective screen width about 160dp. Emulator becomes almost useless.
More info here. https://github.com/travis-ci/docs-travis-ci-com/pull/466