### PR TITLE
LumberYard: close sink before emitting log file to the subscriber

### DIFF
--- a/src/main/java/com/jakewharton/u2020/data/LumberYard.java
+++ b/src/main/java/com/jakewharton/u2020/data/LumberYard.java
@@ -79,6 +79,10 @@ public final class LumberYard {
           for (Entry entry : entries) {
             sink.writeUtf8(entry.prettyPrint()).writeByte('\n');
           }
+          // need to close before emiting file to the subscriber, because when subscriber receives data in the same thread
+          // the file may be truncated
+          sink.close();
+          sink = null;
 
           subscriber.onNext(output);
           subscriber.onCompleted();


### PR DESCRIPTION
Doesn't affect U2020 app, but may affect other apps which use LumberYard.