### PR TITLE
Remove support lib repo component from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ android:
     - platform-tools
     - build-tools-25.0.2
     - android-25
-    - extra-android-m2repository
     - sys-img-armeabi-v7a-android-19
 
 before_script:

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
   //maven {
   //  url 'https://oss.sonatype.org/content/repositories/snapshots/'
   //}
+  google()
   mavenCentral()
 }
 


### PR DESCRIPTION
Since project does not use the local maven repo anymore with #282 this is not needed.