### PR TITLE
Remove now unnecessary findById method.

### DIFF
--- a/app/src/internalDebug/java/com/jakewharton/u2020/ui/debug/AnimationSpeedAdapter.java
+++ b/app/src/internalDebug/java/com/jakewharton/u2020/ui/debug/AnimationSpeedAdapter.java
@@ -7,8 +7,6 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import com.jakewharton.u2020.ui.misc.BindableAdapter;
 
-import static butterknife.ButterKnife.findById;
-
 class AnimationSpeedAdapter extends BindableAdapter<Integer> {
   private static final int[] VALUES = {
       1, 2, 3, 5, 10
@@ -44,7 +42,7 @@ class AnimationSpeedAdapter extends BindableAdapter<Integer> {
   }
 
   @Override public void bindView(Integer item, int position, View view) {
-    TextView tv = findById(view, android.R.id.text1);
+    TextView tv = view.findViewById(android.R.id.text1);
     if (item == 1) {
       tv.setText("Normal");
     } else {

--- a/app/src/internalDebug/java/com/jakewharton/u2020/ui/debug/DebugView.java
+++ b/app/src/internalDebug/java/com/jakewharton/u2020/ui/debug/DebugView.java
@@ -66,7 +66,6 @@ import org.threeten.bp.temporal.TemporalAccessor;
 import retrofit2.mock.NetworkBehavior;
 import timber.log.Timber;
 
-import static butterknife.ButterKnife.findById;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public final class DebugView extends FrameLayout {
@@ -506,7 +505,7 @@ public final class DebugView extends FrameLayout {
     final int originalSelection = networkProxyAddress.isSet() ? ProxyAdapter.PROXY : ProxyAdapter.NONE;
 
     View view = LayoutInflater.from(app).inflate(R.layout.debug_drawer_network_proxy, null);
-    final EditText hostView = findById(view, R.id.debug_drawer_network_proxy_host);
+    final EditText hostView = view.findViewById(R.id.debug_drawer_network_proxy_host);
 
     if(networkProxyAddress.isSet()) {
       String host = networkProxyAddress.get().getHostName();
@@ -541,7 +540,7 @@ public final class DebugView extends FrameLayout {
 
   private void showCustomEndpointDialog(final int originalSelection, String defaultUrl) {
     View view = LayoutInflater.from(app).inflate(R.layout.debug_drawer_network_endpoint, null);
-    final EditText url = findById(view, R.id.debug_drawer_network_endpoint_url);
+    final EditText url = view.findViewById(R.id.debug_drawer_network_endpoint_url);
     url.setText(defaultUrl);
     url.setSelection(url.length());
 

--- a/app/src/internalDebug/java/com/jakewharton/u2020/ui/debug/NetworkDelayAdapter.java
+++ b/app/src/internalDebug/java/com/jakewharton/u2020/ui/debug/NetworkDelayAdapter.java
@@ -7,8 +7,6 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import com.jakewharton.u2020.ui.misc.BindableAdapter;
 
-import static butterknife.ButterKnife.findById;
-
 class NetworkDelayAdapter extends BindableAdapter<Long> {
   private static final long[] VALUES = {
       250, 500, 1000, 2000, 3000, 5000
@@ -44,7 +42,7 @@ class NetworkDelayAdapter extends BindableAdapter<Long> {
   }
 
   @Override public void bindView(Long item, int position, View view) {
-    TextView tv = findById(view, android.R.id.text1);
+    TextView tv = view.findViewById(android.R.id.text1);
     tv.setText(item + "ms");
   }
 

--- a/app/src/internalDebug/java/com/jakewharton/u2020/ui/debug/NetworkErrorAdapter.java
+++ b/app/src/internalDebug/java/com/jakewharton/u2020/ui/debug/NetworkErrorAdapter.java
@@ -7,8 +7,6 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import com.jakewharton.u2020.ui.misc.BindableAdapter;
 
-import static butterknife.ButterKnife.findById;
-
 class NetworkErrorAdapter extends BindableAdapter<Integer> {
   private static final int[] VALUES = {
       0, 3, 10, 25, 50, 75, 100
@@ -44,7 +42,7 @@ class NetworkErrorAdapter extends BindableAdapter<Integer> {
   }
 
   @Override public void bindView(Integer item, int position, View view) {
-    TextView tv = findById(view, android.R.id.text1);
+    TextView tv = view.findViewById(android.R.id.text1);
     if (item == 0) {
       tv.setText("None");
     } else {

--- a/app/src/internalDebug/java/com/jakewharton/u2020/ui/debug/NetworkVarianceAdapter.java
+++ b/app/src/internalDebug/java/com/jakewharton/u2020/ui/debug/NetworkVarianceAdapter.java
@@ -7,8 +7,6 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import com.jakewharton.u2020.ui.misc.BindableAdapter;
 
-import static butterknife.ButterKnife.findById;
-
 class NetworkVarianceAdapter extends BindableAdapter<Integer> {
   private static final int[] VALUES = {
       20, 40, 60
@@ -44,7 +42,7 @@ class NetworkVarianceAdapter extends BindableAdapter<Integer> {
   }
 
   @Override public void bindView(Integer item, int position, View view) {
-    TextView tv = findById(view, android.R.id.text1);
+    TextView tv = view.findViewById(android.R.id.text1);
     tv.setText("±" + item + "%");
   }
 

--- a/app/src/internalDebug/java/com/jakewharton/u2020/ui/debug/ProxyAdapter.java
+++ b/app/src/internalDebug/java/com/jakewharton/u2020/ui/debug/ProxyAdapter.java
@@ -9,8 +9,6 @@ import com.f2prateek.rx.preferences.Preference;
 import com.jakewharton.u2020.ui.misc.BindableAdapter;
 import java.net.InetSocketAddress;
 
-import static butterknife.ButterKnife.findById;
-
 class ProxyAdapter extends BindableAdapter<String> {
   public static final int NONE = 0;
   public static final int PROXY = 1;
@@ -48,7 +46,7 @@ class ProxyAdapter extends BindableAdapter<String> {
   }
 
   @Override public void bindView(String item, int position, View view) {
-    TextView tv = findById(view, android.R.id.text1);
+    TextView tv = view.findViewById(android.R.id.text1);
     tv.setText(item);
   }
 

--- a/app/src/main/java/com/jakewharton/u2020/ui/ViewContainer.java
+++ b/app/src/main/java/com/jakewharton/u2020/ui/ViewContainer.java
@@ -3,13 +3,11 @@ package com.jakewharton.u2020.ui;
 import android.app.Activity;
 import android.view.ViewGroup;
 
-import static butterknife.ButterKnife.findById;
-
 /** An indirection which allows controlling the root container used for each activity. */
 public interface ViewContainer {
   /** The root {@link android.view.ViewGroup} into which the activity should place its contents. */
   ViewGroup forActivity(Activity activity);
 
   /** An {@link ViewContainer} which returns the normal activity content view. */
-  ViewContainer DEFAULT = activity -> findById(activity, android.R.id.content);
+  ViewContainer DEFAULT = activity -> activity.findViewById(android.R.id.content);
 }

--- a/app/src/main/java/com/jakewharton/u2020/ui/misc/EnumAdapter.java
+++ b/app/src/main/java/com/jakewharton/u2020/ui/misc/EnumAdapter.java
@@ -5,7 +5,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
-import butterknife.ButterKnife;
 
 public class EnumAdapter<T extends Enum<T>> extends BindableAdapter<T> {
   private final T[] enumConstants;
@@ -44,7 +43,7 @@ public class EnumAdapter<T extends Enum<T>> extends BindableAdapter<T> {
   }
 
   @Override public final void bindView(T item, int position, View view) {
-    TextView tv = ButterKnife.findById(view, android.R.id.text1);
+    TextView tv = view.findViewById(android.R.id.text1);
     tv.setText(getName(item));
   }
 


### PR DESCRIPTION
Android O's normal findViewById method will perform the same implicit cast.