### PR TITLE
Use applicationIdSuffix for product flavor.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,7 @@ android {
   }
 
   defaultConfig {
+    applicationId 'com.jakewharton.u2020'
     minSdkVersion versions.minSdk
     targetSdkVersion versions.targetSdk
 
@@ -75,11 +76,10 @@ android {
 
     internal {
       dimension 'environment'
-      applicationId 'com.jakewharton.u2020.internal'
+      applicationIdSuffix 'internal'
     }
     production {
       dimension 'environment'
-      applicationId 'com.jakewharton.u2020'
     }
   }
 


### PR DESCRIPTION
https://developer.android.com/studio/build/application-id.html
Gradle applies the build type configuration after the product flavor, so `.internal.debug` is still correct.