### PR TITLE
Update JDK 8 to the latest available for Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ language: android
 jdk:
  - oraclejdk8
 
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer # Updates JDK 8 to the latest available.
+
 android:
   components:
     # Update tools and then platform-tools explicitly so lint gets an updated database. Can be removed once 3.0 is out.


### PR DESCRIPTION
I was stuck wondering why Travis was failing on a project until I realized it was https://github.com/google/error-prone/issues/525.
Worth adding here for people like me who clone u2020 for projects?