### PR TITLE
Update support libraries to 26.0.2.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
       'minSdk': 19,
       'targetSdk': 25,
 
-      'supportLibrary': '26.0.0',
+      'supportLibrary': '26.0.2',
       'dagger': '1.2.5',
       'okhttp': '3.8.1',
       'retrofit': '2.3.0',


### PR DESCRIPTION
This removes the [multidex library from the design library](https://developer.android.com/topic/libraries/support-library/revisions.html#26-0-1). ([These lines could now be removed](https://github.com/JakeWharton/u2020/blob/9870fa4291f5c813ed929aec26c94bee2b92d2b7/build.gradle#L110-L111), if you'd like).
u2020 could exclude `support-media-compat`, too, but maybe not worth it.