### PR TITLE
Replace Android color resources with app defined resources

### DIFF
--- a/app/src/main/res/drawable-v21/selectable_item_background.xml
+++ b/app/src/main/res/drawable-v21/selectable_item_background.xml
@@ -3,6 +3,6 @@
     android:color="@color/selectable_background_pressed"
     >
   <item android:id="@android:id/mask">
-    <color android:color="@android:color/white"/>
+    <color android:color="@color/selectable_background_mask"/>
   </item>
 </ripple>

--- a/app/src/main/res/drawable/selectable_item_background.xml
+++ b/app/src/main/res/drawable/selectable_item_background.xml
@@ -2,5 +2,5 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:state_pressed="true"
       android:drawable="@color/selectable_background_pressed"/>
-  <item android:drawable="@android:color/transparent"/>
+  <item android:drawable="@color/selectable_background"/>
 </selector>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,5 +7,7 @@
   <color name="text_color_secondary">#89000000</color>
   <color name="avatar_stroke">#1a000000</color>
   <color name="timespan_title_text">#ffffffff</color>
+  <color name="selectable_background">#00000000</color>
   <color name="selectable_background_pressed">#1f000000</color>
+  <color name="selectable_background_mask">#ffffffff</color>
 </resources>


### PR DESCRIPTION
On certain devices, OEMs have changed the expected values of color resources, such as `android:color/white`. To err on the side of caution, I've replaced these references with equivalent resources defined in the app.

Note: [See Twitter discussion](https://twitter.com/mandybess/status/910555678476951552)